### PR TITLE
Remove unnecessary and breaking WSA predefine

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -562,7 +562,7 @@ namespace VRTK
             {
                 return type;
             }
-#if !UNITY_WSA
+
             Assembly[] foundAssemblies = AppDomain.CurrentDomain.GetAssemblies();
             for (int i = 0; i < foundAssemblies.Length; i++)
             {
@@ -572,7 +572,7 @@ namespace VRTK
                     return type;
                 }
             }
-#endif
+
             return null;
         }
 


### PR DESCRIPTION
No idea why this was in in the first place but it's not needed and only breaks the code 