### PR TITLE
Fix runtime error of controller with newer Unity versions.

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
@@ -534,7 +534,9 @@ namespace VRTK
             touchRigidBody.isKinematic = true;
             touchRigidBody.useGravity = false;
             touchRigidBody.constraints = RigidbodyConstraints.FreezeAll;
+#if !UNITY_2018_3_OR_NEWER // Newer unity versions do not support continuous collision detection on kinematic bodies.
             touchRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+#endif
         }
 
         protected virtual void EmitControllerRigidbodyEvent(bool state)


### PR DESCRIPTION
 - fix: VRTK_InteractTouch set invalid Rigidbody configuration causing
        runtime error messages on newer Unity2018 versions.